### PR TITLE
Clean outdated upload file refs

### DIFF
--- a/utils/arrays.js
+++ b/utils/arrays.js
@@ -1,0 +1,5 @@
+exports.asyncForEach = async (arr, cb) => {
+  for (let i = 0; i < arr.length; i++) {
+    await cb(arr[i], i, arr);
+  }
+};


### PR DESCRIPTION
- add "asyncForEach" utility function
- add "cleanNonExistingProjectFiles" function to clear not existing upload file references from project document in DB.
- run this funcition before GET request "getSingleProfile" will return project data